### PR TITLE
hlte: Set preferred network to LTE/CDMA/EvDo for Sprint

### DIFF
--- a/init/init_hlte.cpp
+++ b/init/init_hlte.cpp
@@ -90,7 +90,7 @@ void init_target_properties()
         property_override("ro.build.description", "hltespr-user 5.0 LRX21V N900PVPSEPL1 release-keys");
         property_override("ro.product.model", "SM-N900P");
         property_override("ro.product.device", "hltespr");
-        cdma_properties("Sprint", "310120", "10", "1");
+        cdma_properties("Sprint", "310120", "8", "1");
     } else {
         gsm_properties();
     }


### PR DESCRIPTION
* May help prevent bouncing between GSM and CDMA

Change-Id: I6afe60cb4aafcd0be34cf55482114c5f683ebbd3